### PR TITLE
added rule for aprendido.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /public/bundles/
 /var/
 /vendor/
+aprendido.txt
 ###< symfony/framework-bundle ###


### PR DESCRIPTION
I have added this rule due to the existence of a local file used for quick notes within the project. You should not go to the repository since it is not necessary